### PR TITLE
Create a new release script that switches to the release branch, runs…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "start": "webpack --watch",
     "build": "webpack -p",
+    "release": "git checkout -B release && webpack -p && git add -f ./client/dist/*.js && git add -f ./client/dist/*.css", 
     "test": "./node_modules/.bin/eslint client/src/js/*.js",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
… webpack, and then adds the dist js and css files to the repo.

This is a good start. What this will do is:

1. Create a new branch called "release," or if it exists, it will switch to that branch and reset it. 
2. Run `webpack` with the `-p` instruction as per `build`. 
3. Forcibly add all CSS files in the dist directory.
4. Forcibly add all JS files in the dist directory. 

I had an issue with webpack building on my Windows install, so I wasn't able to fully test this, however, I did test each portion separately. 

From what I could tell from other repositories that use npm scripting and webpack, they don't ignore the dist/ file, but they implement different models that avoid conflicts:

http://nvie.com/posts/a-successful-git-branching-model/

This could be expanded for npm releases and git tagging:

http://www.marcusoft.net/2015/08/npm-scripting-git-version-and-deploy.html

Hope this helps. 